### PR TITLE
This change sets the port dynamically based on `process` variable

### DIFF
--- a/app.js
+++ b/app.js
@@ -28,7 +28,7 @@ app.use('/investment',investmentRoutes);
 cartodbClient.on('connect',function(){
 	console.log('Connected to CartoDB...');
 
-	app.listen(8080,function(){
+	app.listen(42951,function(){
 		console.log('App listening on port 8080');
 	});
 })

--- a/app.js
+++ b/app.js
@@ -10,6 +10,8 @@ var parcelRoutes = require('./routes/parcelRoutes'); //for individual parcels
 var cityRoutes = require('./routes/cityRoutes');
 var assetRoutes = require('./routes/assetRoutes');
 var investmentRoutes = require('./routes/investmentRoutes');
+
+//Port configuration
 var port = process.env.PORT || 8080;
 
 //Middleware

--- a/app.js
+++ b/app.js
@@ -10,7 +10,7 @@ var parcelRoutes = require('./routes/parcelRoutes'); //for individual parcels
 var cityRoutes = require('./routes/cityRoutes');
 var assetRoutes = require('./routes/assetRoutes');
 var investmentRoutes = require('./routes/investmentRoutes');
-
+var port = process.env.PORT || 8080;
 
 //Middleware
 app.use(express.static('public'));
@@ -28,8 +28,8 @@ app.use('/investment',investmentRoutes);
 cartodbClient.on('connect',function(){
 	console.log('Connected to CartoDB...');
 
-	app.listen(process.env.PORT,function(){
-		console.log('App listening on port',process.env.PORT);
+	app.listen(port, function(){
+		console.log('App listening on port', port);
 	});
 })
 

--- a/app.js
+++ b/app.js
@@ -28,8 +28,8 @@ app.use('/investment',investmentRoutes);
 cartodbClient.on('connect',function(){
 	console.log('Connected to CartoDB...');
 
-	app.listen(32769,function(){
-		console.log('App listening on port 32769');
+	app.listen(process.env.PORT,function(){
+		console.log('App listening on port',process.env.PORT);
 	});
 })
 

--- a/app.js
+++ b/app.js
@@ -28,8 +28,8 @@ app.use('/investment',investmentRoutes);
 cartodbClient.on('connect',function(){
 	console.log('Connected to CartoDB...');
 
-	app.listen(42951,function(){
-		console.log('App listening on port 8080');
+	app.listen(32769,function(){
+		console.log('App listening on port 32769');
 	});
 })
 

--- a/public/index.html
+++ b/public/index.html
@@ -3,7 +3,7 @@
 	<head>
 		<title>CITY X CITY (Beta)</title>
 		<link rel="stylesheet" href="http://cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.3/leaflet.css" />
-		<link rel="stylesheet" href="bower_components\bootstrap\dist\css\bootstrap.min.css"/>
+		<link rel="stylesheet" href="bower_components/bootstrap/dist/css/bootstrap.min.css"/>
 		<link href="style/bootstrap-switch.min.css" rel="stylesheet"/>
 		<link href="style/bootstrap-multiselect.css" rel="stylesheet" />
 		<link href="style/style.css" rel="stylesheet"/>


### PR DESCRIPTION
To deploy with Heroku-like Dokku, node needs to set the port dynamically. This change allows the port to be set by `process` global or defaults to 8080 if undefined. Also fixed Firefox compatibility issue.
